### PR TITLE
Several changes/additions

### DIFF
--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -95,16 +95,8 @@ public class SuperbVoteConfiguration {
         String name = section.getName();
 
         List<String> commands = section.getStringList("commands");
-        VoteMessage broadcast = VoteMessages.from(section, "broadcast-message");
-        VoteMessage playerMessage = VoteMessages.from(section, "player-message");
-
-        if (broadcast == null) {
-            throw new RuntimeException("'broadcast-message' missing in section '" + name + "' (do you need to enable 'inherit-default'?)");
-        }
-
-        if (playerMessage == null) {
-            throw new RuntimeException("'player-message' missing in section '" + name + "' (do you need to enable 'inherit-default'?)");
-        }
+        VoteMessage broadcast = VoteMessages.from(section, "broadcast-message", true);
+        VoteMessage playerMessage = VoteMessages.from(section, "player-message", true);
 
         List<RewardMatcher> rewards = RewardMatchers.getMatchers(section.getConfigurationSection("if"));
         boolean cascade = section.getBoolean("allow-cascading");

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -1,11 +1,23 @@
 package io.minimum.minecraft.superbvote.configuration;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.pool.HikariPool;
+
 import io.minimum.minecraft.superbvote.SuperbVote;
 import io.minimum.minecraft.superbvote.commands.VoteCommand;
+import io.minimum.minecraft.superbvote.configuration.message.JsonTextMessage;
 import io.minimum.minecraft.superbvote.configuration.message.OfflineVoteMessages;
 import io.minimum.minecraft.superbvote.configuration.message.PlainStringMessage;
 import io.minimum.minecraft.superbvote.configuration.message.VoteMessage;
@@ -19,15 +31,6 @@ import io.minimum.minecraft.superbvote.votes.rewards.matchers.ChanceRewardMatche
 import io.minimum.minecraft.superbvote.votes.rewards.matchers.RewardMatcher;
 import io.minimum.minecraft.superbvote.votes.rewards.matchers.RewardMatchers;
 import lombok.Getter;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.MemoryConfiguration;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class SuperbVoteConfiguration {
     private final ConfigurationSection configuration;
@@ -71,7 +74,9 @@ public class SuperbVoteConfiguration {
         reminderMessage = VoteMessages.from(configuration, "vote-reminder.message");
 
         if (configuration.getBoolean("vote-command.enabled")) {
-            voteCommand = new VoteCommand(VoteMessages.from(configuration, "vote-command.text"));
+        	boolean useJson = configuration.getBoolean("vote-command.use-json-text");
+        	VoteMessage voteMessage =  VoteMessages.from(configuration, "vote-command.text", false, useJson);
+        	voteCommand = new VoteCommand(voteMessage);
         } else {
             voteCommand = null;
         }
@@ -95,8 +100,8 @@ public class SuperbVoteConfiguration {
         String name = section.getName();
 
         List<String> commands = section.getStringList("commands");
-        VoteMessage broadcast = VoteMessages.from(section, "broadcast-message", true);
-        VoteMessage playerMessage = VoteMessages.from(section, "player-message", true);
+        VoteMessage broadcast = VoteMessages.from(section, "broadcast-message", true, false);
+        VoteMessage playerMessage = VoteMessages.from(section, "player-message", true, false);
 
         List<RewardMatcher> rewards = RewardMatchers.getMatchers(section.getConfigurationSection("if"));
         boolean cascade = section.getBoolean("allow-cascading");

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -74,9 +74,9 @@ public class SuperbVoteConfiguration {
         reminderMessage = VoteMessages.from(configuration, "vote-reminder.message");
 
         if (configuration.getBoolean("vote-command.enabled")) {
-        	boolean useJson = configuration.getBoolean("vote-command.use-json-text");
-        	VoteMessage voteMessage =  VoteMessages.from(configuration, "vote-command.text", false, useJson);
-        	voteCommand = new VoteCommand(voteMessage);
+            boolean useJson = configuration.getBoolean("vote-command.use-json-text");
+            VoteMessage voteMessage =  VoteMessages.from(configuration, "vote-command.text", false, useJson);
+            voteCommand = new VoteCommand(voteMessage);
         } else {
             voteCommand = null;
         }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/JsonTextMessage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/JsonTextMessage.java
@@ -7,21 +7,21 @@ import io.minimum.minecraft.superbvote.votes.Vote;
 
 public class JsonTextMessage extends MessageBase implements VoteMessage
 {
-	private final String message;
+    private final String message;
 
     public JsonTextMessage(String message) {
         this.message = message;
     }
-    
-	@Override
-	public void sendAsBroadcast(Player player, Vote vote) {
-		String jsonString = getAsBroadcast(message, vote);
-		Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + jsonString);
-	}
 
-	@Override
-	public void sendAsReminder(Player player) {
-		String jsonString = getAsReminder(message, player);
-		Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + jsonString);
-	}
+    @Override
+    public void sendAsBroadcast(Player player, Vote vote) {
+        String jsonString = getAsBroadcast(message, vote);
+        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + jsonString);
+    }
+
+    @Override
+    public void sendAsReminder(Player player) {
+        String jsonString = getAsReminder(message, player);
+        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + jsonString);
+    }
 }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/JsonTextMessage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/JsonTextMessage.java
@@ -1,0 +1,27 @@
+package io.minimum.minecraft.superbvote.configuration.message;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import io.minimum.minecraft.superbvote.votes.Vote;
+
+public class JsonTextMessage extends MessageBase implements VoteMessage
+{
+	private final String message;
+
+    public JsonTextMessage(String message) {
+        this.message = message;
+    }
+    
+	@Override
+	public void sendAsBroadcast(Player player, Vote vote) {
+		String jsonString = getAsBroadcast(message, vote);
+		Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + jsonString);
+	}
+
+	@Override
+	public void sendAsReminder(Player player) {
+		String jsonString = getAsReminder(message, player);
+		Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + player.getName() + " " + jsonString);
+	}
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/MessageBase.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/MessageBase.java
@@ -1,0 +1,38 @@
+package io.minimum.minecraft.superbvote.configuration.message;
+
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.google.common.collect.ImmutableList;
+
+import io.minimum.minecraft.superbvote.configuration.message.placeholder.ClipsPlaceholderProvider;
+import io.minimum.minecraft.superbvote.configuration.message.placeholder.PlaceholderProvider;
+import io.minimum.minecraft.superbvote.configuration.message.placeholder.SuperbVotePlaceholderProvider;
+import io.minimum.minecraft.superbvote.votes.Vote;
+
+public class MessageBase
+{
+    protected static final List<PlaceholderProvider> PROVIDER_LIST = ImmutableList.of(new SuperbVotePlaceholderProvider(),
+        new ClipsPlaceholderProvider());
+
+    protected String getAsBroadcast(String message, Vote vote) {
+        Player onlineVoted = Bukkit.getPlayerExact(vote.getName());
+        for (PlaceholderProvider provider : PROVIDER_LIST) {
+            if (provider.canUse()) {
+            	message = provider.applyForBroadcast(onlineVoted, message, vote);
+            }
+        }
+        return message;
+    }
+
+    protected String getAsReminder(String message, Player player) {
+        for (PlaceholderProvider provider : PROVIDER_LIST) {
+            if (provider.canUse()) {
+            	message = provider.applyForReminder(player, message);
+            }
+        }
+        return message;
+    }
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/PlainStringMessage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/PlainStringMessage.java
@@ -1,21 +1,15 @@
 package io.minimum.minecraft.superbvote.configuration.message;
 
-import com.google.common.collect.ImmutableList;
-import io.minimum.minecraft.superbvote.configuration.message.placeholder.ClipsPlaceholderProvider;
-import io.minimum.minecraft.superbvote.configuration.message.placeholder.PlaceholderProvider;
-import io.minimum.minecraft.superbvote.configuration.message.placeholder.SuperbVotePlaceholderProvider;
-import io.minimum.minecraft.superbvote.votes.Vote;
-import org.bukkit.Bukkit;
+import java.util.UUID;
+
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.util.List;
-import java.util.UUID;
+import io.minimum.minecraft.superbvote.configuration.message.placeholder.PlaceholderProvider;
+import io.minimum.minecraft.superbvote.votes.Vote;
 
-public class PlainStringMessage implements VoteMessage, OfflineVoteMessage {
-    private static final List<PlaceholderProvider> PROVIDER_LIST = ImmutableList.of(new SuperbVotePlaceholderProvider(),
-            new ClipsPlaceholderProvider());
+public class PlainStringMessage extends MessageBase implements VoteMessage, OfflineVoteMessage {
 
     private final String message;
 
@@ -25,33 +19,12 @@ public class PlainStringMessage implements VoteMessage, OfflineVoteMessage {
 
     @Override
     public void sendAsBroadcast(Player player, Vote vote) {
-        player.sendMessage(getAsBroadcast(vote));
-    }
-
-    protected String getAsBroadcast(Vote vote) {
-        Player onlineVoted = Bukkit.getPlayerExact(vote.getName());
-        String replaced = message;
-        for (PlaceholderProvider provider : PROVIDER_LIST) {
-            if (provider.canUse()) {
-                replaced = provider.applyForBroadcast(onlineVoted, replaced, vote);
-            }
-        }
-        return replaced;
+        player.sendMessage(getAsBroadcast(message, vote));
     }
 
     @Override
     public void sendAsReminder(Player player) {
-        player.sendMessage(getAsReminder(player));
-    }
-
-    protected String getAsReminder(Player player) {
-        String replaced = message;
-        for (PlaceholderProvider provider : PROVIDER_LIST) {
-            if (provider.canUse()) {
-                replaced = provider.applyForReminder(player, replaced);
-            }
-        }
-        return replaced;
+        player.sendMessage(getAsReminder(message, player));
     }
 
     @Override

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/VoteMessages.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/VoteMessages.java
@@ -7,9 +7,19 @@ import org.bukkit.configuration.ConfigurationSection;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class VoteMessages {
     public static VoteMessage from(ConfigurationSection root, String section) {
-        if (root.isString(section)) {
-            return new PlainStringMessage(root.getString(section));
-        }
+        return from(root, section, false);
+    }
+
+    public static VoteMessage from(ConfigurationSection root, String section, boolean optional) {
+        if (root.contains(section)) {
+	    if (root.isString(section)) {
+		return new PlainStringMessage(root.getString(section));
+	    }
+	}
+	else if (optional) {
+	    return null;
+	}
+
         throw new IllegalArgumentException("Section '" + section + "' (under " + root.getCurrentPath() + ") doesn't contain a valid message section.");
     }
 }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/VoteMessages.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/VoteMessages.java
@@ -12,14 +12,14 @@ public class VoteMessages {
 
     public static VoteMessage from(ConfigurationSection root, String section, boolean optional, boolean jsonText) {
         if (root.contains(section)) {
-	        if (root.isString(section)) {
-	        	String message = root.getString(section);
-		        return jsonText ?new JsonTextMessage(message) : new PlainStringMessage(message);
-	        }
-	    }
-	    else if (optional) {
-	        return null;
-	    }
+            if (root.isString(section)) {
+                String message = root.getString(section);
+                return jsonText ? new JsonTextMessage(message) : new PlainStringMessage(message);
+            }
+        }
+        else if (optional) {
+            return null;
+        }
 
         throw new IllegalArgumentException("Section '" + section + "' (under " + root.getCurrentPath() + ") doesn't contain a valid message section.");
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/VoteMessages.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/VoteMessages.java
@@ -7,18 +7,19 @@ import org.bukkit.configuration.ConfigurationSection;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class VoteMessages {
     public static VoteMessage from(ConfigurationSection root, String section) {
-        return from(root, section, false);
+        return from(root, section, false, false);
     }
 
-    public static VoteMessage from(ConfigurationSection root, String section, boolean optional) {
+    public static VoteMessage from(ConfigurationSection root, String section, boolean optional, boolean jsonText) {
         if (root.contains(section)) {
-	    if (root.isString(section)) {
-		return new PlainStringMessage(root.getString(section));
+	        if (root.isString(section)) {
+	        	String message = root.getString(section);
+		        return jsonText ?new JsonTextMessage(message) : new PlainStringMessage(message);
+	        }
 	    }
-	}
-	else if (optional) {
-	    return null;
-	}
+	    else if (optional) {
+	        return null;
+	    }
 
         throw new IllegalArgumentException("Section '" + section + "' (under " + root.getCurrentPath() + ") doesn't contain a valid message section.");
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -67,7 +67,7 @@ public class SuperbVoteListener implements Listener {
                     throw new RuntimeException("No vote reward found for '" + vote + "'");
                 }
 
-                if (!vote.isFakeVote()) {
+                if (!vote.isFakeVote() || SuperbVote.getPlugin().getConfig().getBoolean("votes.process-fake-votes")) {
                     SuperbVote.getPlugin().getVoteStorage().issueVote(vote);
                 }
 

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/VoteReward.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/VoteReward.java
@@ -24,7 +24,8 @@ public class VoteReward {
         for (Player player : Bukkit.getOnlinePlayers()) {
             if (player == onlinePlayer && playerAnnounce) {
                 playerMessage.sendAsBroadcast(player, vote);
-            } else if (broadcast) {
+            }
+	    if (broadcast) {
                 broadcastMessage.sendAsBroadcast(player, vote);
             }
         }

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/VoteReward.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/VoteReward.java
@@ -22,10 +22,10 @@ public class VoteReward {
     public void broadcastVote(Vote vote, boolean playerAnnounce, boolean broadcast) {
         Player onlinePlayer = Bukkit.getPlayer(vote.getUuid());
         for (Player player : Bukkit.getOnlinePlayers()) {
-            if (player == onlinePlayer && playerAnnounce) {
+            if (playerMessage != null && player == onlinePlayer && playerAnnounce) {
                 playerMessage.sendAsBroadcast(player, vote);
             }
-	    if (broadcast) {
+	    if (broadcastMessage != null && broadcast) {
                 broadcastMessage.sendAsBroadcast(player, vote);
             }
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -62,8 +62,11 @@ broadcast:
   queued: true
 
 # Vote command.
+# See http://www.minecraftforum.net/forums/minecraft-discussion/redstone-discussion-and/351959-1-9-json-text-component-for-tellraw-title-books
+# and https://www.minecraftjson.com for json text format
 vote-command:
   enabled: false
+  use-json-text: false
   text: |-
     You could vote for us, but the owner forgot to add the list of websites to vote at!
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,9 @@ votes:
   # Whether or not to treat the server as online-mode. This is mostly required for BungeeCord setups.
   force-online-mode: false
 
+  # Whether or not to treat fake votes as real votes
+  process-fake-votes: true
+
 # Rewards. This is the main section you will need to edit. Ordering is important.
 rewards:
   # Example of matchers.


### PR DESCRIPTION
Player message and broadcast message should not be mutually exclusive.  Am I the only one that would like to have both?

Option for counting fake votes as real votes.  This is useful for testing cumulative rules.

player-message and broadcast-message are not mandatory.  I don't want player messages most of the time and there was always a blank like being sent.

json text support for /vote.  This allows for clickable links in the vote message.