### PR TITLE
Adding ssl option to config so users can silence warnings when connnecting to databases without SSL

### DIFF
--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -182,9 +182,10 @@ public class SuperbVoteConfiguration {
                 String database = configuration.getString("storage.mysql.database", "superbvote");
                 String table = configuration.getString("storage.mysql.table", "superbvote");
                 boolean readOnly = configuration.getBoolean("storage.mysql.read-only");
+                boolean ssl = configuration.getBoolean("storage.mysql.ssl");
 
                 HikariConfig config = new HikariConfig();
-                config.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database);
+                config.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=" + ssl);
                 config.setUsername(username);
                 config.setPassword(password);
                 config.setMinimumIdle(2);

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -96,7 +96,9 @@ public class SuperbVoteListener implements Listener {
             return;
         }
 
-        Bukkit.getScheduler().runTaskAsynchronously(SuperbVote.getPlugin(), () -> {
+        long delay = 100L; // 100 ticks = 5 seconds to delay
+
+        Bukkit.getScheduler().runTaskLaterAsynchronously(SuperbVote.getPlugin(), () -> {
             // Update names in MySQL, if it is being used.
             if (SuperbVote.getPlugin().getVoteStorage() instanceof MysqlVoteStorage) {
                 ((MysqlVoteStorage) SuperbVote.getPlugin().getVoteStorage()).updateName(event.getPlayer());
@@ -120,7 +122,7 @@ public class SuperbVoteListener implements Listener {
                 MessageContext context = new MessageContext(null, pv, event.getPlayer());
                 SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(event.getPlayer(), context);
             }
-        });
+        }, delay);
     }
 
     private void afterVoteProcessing() {

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -108,6 +108,10 @@ public class SuperbVoteListener implements Listener {
             PlayerVotes pv = SuperbVote.getPlugin().getVoteStorage().getVotes(event.getPlayer().getUniqueId());
             List<Vote> votes = SuperbVote.getPlugin().getQueuedVotes().getAndRemoveVotes(event.getPlayer().getUniqueId());
             if (!votes.isEmpty()) {
+                // Send message to player letting them know why they're receiving a bunch of random gifts
+                String queueMessage = ChatColor.translateAlternateColorCodes('&', SuperbVote.getPlugin().getConfig().getString("queue-message"));
+                event.getPlayer().sendMessage(queueMessage);
+
                 for (Vote vote : votes) {
                     processVote(pv, vote, false, false, true);
                     pv = new PlayerVotes(pv.getUuid(), event.getPlayer().getName(),pv.getVotes() + 1, PlayerVotes.Type.CURRENT);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -50,6 +50,7 @@ rewards:
 
 # Whether or not players need to be online to vote. If set, offline player votes are queued for when the player next logs in.
 require-online: true
+queue-message: "&aThanks for voting recently! You will now receive your prizes."
 
 # Broadcast settings:
 broadcast:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,6 +15,7 @@ storage:
     database: superbvote
     table: votes
     read-only: false
+    ssl: true
 
 # General vote configuration.
 votes:


### PR DESCRIPTION
Hi,

Sorry for any hiccups, this is my first time doing a pull request so I am learning. 

The changes I've made allow for users to silence the following warnings that appear in console by setting 'ssl' to 'false' when they are using a database without SSL (like on a paid server host):

`
WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.
`