### PR TITLE
add votes.one-vote-per-day option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ buildNumber.properties
 .classpath
 .project
 .settings/*
+
+# IntelliJ
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>io.minimum.minecraft</groupId>
     <artifactId>SuperbVote</artifactId>
-    <version>0.5.6-CORP-2</version>
+    <version>0.6.0-CORP</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <build>
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.6.0</version>
                 <configuration>
                     <relocations>
                         <relocation>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -116,6 +116,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.minimum.minecraft</groupId>
     <artifactId>SuperbVote</artifactId>
-    <version>0.6.0-CORP</version>
+    <version>0.6.1-CORP</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.minimum.minecraft</groupId>
     <artifactId>SuperbVote</artifactId>
-    <version>0.5.5</version>
+    <version>0.5.6-CORP-2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.minimum.minecraft</groupId>
     <artifactId>SuperbVote</artifactId>
-    <version>0.6.1-CORP</version>
+    <version>0.6.2-CORP</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
     <artifactId>SuperbVote</artifactId>
     <version>0.5.5</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
     <build>
         <resources>
             <resource>
@@ -18,17 +24,8 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.4.1</version>
                 <configuration>
                     <relocations>
                         <relocation>
@@ -40,6 +37,13 @@
                             <shadedPattern>io.minimum.minecraft.superbvote.slf4j</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Built-By>maven</Built-By>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>
@@ -59,7 +63,7 @@
         </repository>
         <repository>
             <id>clip-repo</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>bintray-nuvotifier-repo</id>
@@ -75,38 +79,43 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.0</version>
+            <version>1.18.26</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.NuVotifier.NuVotifier</groupId>
-            <artifactId>nuvotifier-bukkit</artifactId>
-            <version>v2.6.0</version>
+            <groupId>com.github.NuVotifier</groupId>
+            <artifactId>NuVotifier</artifactId>
+            <version>2.7.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.7.6</version>
+            <version>5.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.8.2</version>
+            <version>2.11.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
-            <version>1.7</version>
+            <version>1.7.1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
@@ -75,8 +75,7 @@ public class SuperbVote extends JavaPlugin {
         }
 
         getCommand("superbvote").setExecutor(new SuperbVoteCommand());
-        getCommand("vote").setExecutor(configuration.getVoteCommand());
-        getCommand("votestreak").setExecutor(configuration.getVoteStreakCommand());
+        registerCommands();
 
         getServer().getPluginManager().registerEvents(new SuperbVoteListener(), this);
         getServer().getPluginManager().registerEvents(new TopPlayerSignListener(), this);
@@ -124,8 +123,7 @@ public class SuperbVote extends JavaPlugin {
         scoreboardHandler.reload();
         voteServiceCooldown = new VoteServiceCooldown(getConfig().getInt("votes.cooldown-per-service", 3600));
         getServer().getScheduler().runTaskAsynchronously(this, getScoreboardHandler()::doPopulate);
-        getCommand("vote").setExecutor(configuration.getVoteCommand());
-        getCommand("votestreak").setExecutor(configuration.getVoteStreakCommand());
+        registerCommands();
 
         if (voteReminderTask != null) {
             voteReminderTask.cancel();
@@ -140,5 +138,14 @@ public class SuperbVote extends JavaPlugin {
 
     public ClassLoader _exposeClassLoader() {
         return getClassLoader();
+    }
+
+    private void registerCommands() {
+        if (configuration.getVoteCommand() != null) {
+            getCommand("vote").setExecutor(configuration.getVoteCommand());
+        }
+        if (configuration.getVoteStreakCommand() != null) {
+            getCommand("votestreak").setExecutor(configuration.getVoteStreakCommand());
+        }
     }
 }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -202,6 +202,11 @@ public class SuperbVoteConfiguration {
                     file = "votes.json";
                     SuperbVote.getPlugin().getLogger().info("No file found in configuration, using 'votes.json'.");
                 }
+                if (configuration.getBoolean("votes.one-vote-per-day")) {
+                    SuperbVote.getPlugin().getLogger()
+                            .warning("votes.one-vote-per-day=true is not fully supported with JSON storage! " +
+                                    "Use mysql instead if you need this feature to work properly.");
+                }
                 return new JsonVoteStorage(new File(SuperbVote.getPlugin().getDataFolder(), file));
             case "mysql":
                 String host = configuration.getString("storage.mysql.host", "localhost");

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/JsonVoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/JsonVoteStorage.java
@@ -90,7 +90,7 @@ public class JsonVoteStorage implements VoteStorage {
     }
 
     @Override
-    public void addVote(Vote vote) {
+    public void addVote(Vote vote, PlayerVotes playerVotes) {
         Preconditions.checkNotNull(vote, "vote");
         rwl.writeLock().lock();
         try {
@@ -144,9 +144,9 @@ public class JsonVoteStorage implements VoteStorage {
         try {
             PlayerRecord pr = voteCounts.get(player);
             if (pr == null) {
-                return new PlayerVotes(player, null, 0, null, PlayerVotes.Type.CURRENT);
+                return new PlayerVotes(player, null, 0, Collections.emptyMap(), PlayerVotes.Type.CURRENT);
             }
-            return new PlayerVotes(player, pr.lastKnownUsername, pr.votes, Date.from(Instant.ofEpochMilli(pr.lastVoted)), PlayerVotes.Type.CURRENT);
+            return new PlayerVotes(player, pr.lastKnownUsername, pr.votes, Collections.emptyMap(), PlayerVotes.Type.CURRENT);
         } finally {
             rwl.readLock().unlock();
         }
@@ -163,7 +163,8 @@ public class JsonVoteStorage implements VoteStorage {
                     .skip(skip)
                     .limit(amount)
                     .map(e -> new PlayerVotes(e.getKey(), e.getValue().lastKnownUsername, e.getValue().votes,
-                            Date.from(Instant.ofEpochMilli(e.getValue().lastVoted)), PlayerVotes.Type.CURRENT))
+                            Collections.emptyMap(),
+                            PlayerVotes.Type.CURRENT))
                     .collect(Collectors.toList());
         } finally {
             rwl.readLock().unlock();

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/JsonVoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/JsonVoteStorage.java
@@ -143,8 +143,10 @@ public class JsonVoteStorage implements VoteStorage {
         rwl.readLock().lock();
         try {
             PlayerRecord pr = voteCounts.get(player);
-            return new PlayerVotes(player, pr != null ? pr.lastKnownUsername : null, pr == null ? 0 : pr.votes,
-                    PlayerVotes.Type.CURRENT);
+            if (pr == null) {
+                return new PlayerVotes(player, null, 0, null, PlayerVotes.Type.CURRENT);
+            }
+            return new PlayerVotes(player, pr.lastKnownUsername, pr.votes, Date.from(Instant.ofEpochMilli(pr.lastVoted)), PlayerVotes.Type.CURRENT);
         } finally {
             rwl.readLock().unlock();
         }
@@ -160,7 +162,8 @@ public class JsonVoteStorage implements VoteStorage {
                     .sorted(Collections.reverseOrder(Comparator.comparing(Map.Entry::getValue)))
                     .skip(skip)
                     .limit(amount)
-                    .map(e -> new PlayerVotes(e.getKey(), e.getValue().lastKnownUsername, e.getValue().votes, PlayerVotes.Type.CURRENT))
+                    .map(e -> new PlayerVotes(e.getKey(), e.getValue().lastKnownUsername, e.getValue().votes,
+                            Date.from(Instant.ofEpochMilli(e.getValue().lastVoted)), PlayerVotes.Type.CURRENT))
                     .collect(Collectors.toList());
         } finally {
             rwl.readLock().unlock();

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/MysqlVoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/MysqlVoteStorage.java
@@ -216,19 +216,19 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
     public PlayerVotes getVotes(UUID player) {
         Preconditions.checkNotNull(player, "player");
         try (Connection connection = dbPool.getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("SELECT last_name, votes FROM " + tableName + " WHERE uuid = ?")) {
+            try (PreparedStatement statement = connection.prepareStatement("SELECT last_name, votes, last_vote FROM " + tableName + " WHERE uuid = ?")) {
                 statement.setString(1, player.toString());
                 try (ResultSet resultSet = statement.executeQuery()) {
                     if (resultSet.next()) {
-                        return new PlayerVotes(player, resultSet.getString(1), resultSet.getInt(2), PlayerVotes.Type.CURRENT);
+                        return new PlayerVotes(player, resultSet.getString(1), resultSet.getInt(2), resultSet.getDate(3), PlayerVotes.Type.CURRENT);
                     } else {
-                        return new PlayerVotes(player, null, 0, PlayerVotes.Type.CURRENT);
+                        return new PlayerVotes(player, null, 0, null, PlayerVotes.Type.CURRENT);
                     }
                 }
             }
         } catch (SQLException e) {
             SuperbVote.getPlugin().getLogger().log(Level.SEVERE, "Unable to get votes for " + player.toString(), e);
-            return new PlayerVotes(player, null, 0, PlayerVotes.Type.CURRENT);
+            return new PlayerVotes(player, null, 0, null, PlayerVotes.Type.CURRENT);
         }
     }
 
@@ -236,14 +236,14 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
     public List<PlayerVotes> getTopVoters(int amount, int page) {
         int offset = page * amount;
         try (Connection connection = dbPool.getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("SELECT uuid, last_name, votes FROM " + tableName + " WHERE votes > 0 ORDER BY votes DESC " +
+            try (PreparedStatement statement = connection.prepareStatement("SELECT uuid, last_name, votes, last_vote FROM " + tableName + " WHERE votes > 0 ORDER BY votes DESC " +
                     "LIMIT " + amount + " OFFSET " + offset)) {
                 try (ResultSet resultSet = statement.executeQuery()) {
                     List<PlayerVotes> records = new ArrayList<>();
                     while (resultSet.next()) {
                         UUID uuid = UUID.fromString(resultSet.getString(1));
                         String name = resultSet.getString(2);
-                        records.add(new PlayerVotes(uuid, name, resultSet.getInt(3), PlayerVotes.Type.CURRENT));
+                        records.add(new PlayerVotes(uuid, name, resultSet.getInt(3), resultSet.getDate(4), PlayerVotes.Type.CURRENT));
                     }
                     return records;
                 }
@@ -293,7 +293,7 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
         List<PlayerVotes> votes = new ArrayList<>();
         try (Connection connection = dbPool.getConnection()) {
             String valueStatement = Joiner.on(", ").join(Collections.nCopies(onlinePlayers.size(), "?"));
-            try (PreparedStatement statement = connection.prepareStatement("SELECT uuid, last_name, votes, (DATE(last_vote) = CURRENT_DATE()) AS has_voted_today FROM " + tableName + " WHERE uuid IN (" + valueStatement + ")")) {
+            try (PreparedStatement statement = connection.prepareStatement("SELECT uuid, last_name, votes, last_vote, (DATE(last_vote) = CURRENT_DATE()) AS has_voted_today FROM " + tableName + " WHERE uuid IN (" + valueStatement + ")")) {
                 for (int i = 0; i < onlinePlayers.size(); i++) {
                     statement.setString(i + 1, onlinePlayers.get(i).toString());
                 }
@@ -302,12 +302,13 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
                     while (resultSet.next()) {
                         UUID uuid = UUID.fromString(resultSet.getString(1));
                         found.add(uuid);
-                        if (resultSet.getBoolean(4)) {
+                        if (resultSet.getBoolean(5)) {
                             continue; // already voted today
                         }
                         PlayerVotes pv = new PlayerVotes(UUID.fromString(resultSet.getString(1)),
                                 resultSet.getString(2),
                                 resultSet.getInt(3),
+                                resultSet.getDate(4),
                                 PlayerVotes.Type.CURRENT);
                         votes.add(pv);
                     }
@@ -317,7 +318,7 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
                 List<UUID> missing = new ArrayList<>(onlinePlayers);
                 missing.removeAll(found);
                 for (UUID uuid : missing) {
-                    votes.add(new PlayerVotes(uuid, null, 0, PlayerVotes.Type.CURRENT));
+                    votes.add(new PlayerVotes(uuid, null, 0, null, PlayerVotes.Type.CURRENT));
                 }
             }
             return votes;

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/VoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/VoteStorage.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface VoteStorage {
-    void addVote(Vote vote);
+    void addVote(Vote vote, PlayerVotes playerVotes);
 
     default void setVotes(UUID player, int votes) {
         setVotes(player, votes, System.currentTimeMillis());

--- a/src/main/java/io/minimum/minecraft/superbvote/util/PlayerVotes.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/util/PlayerVotes.java
@@ -1,19 +1,27 @@
 package io.minimum.minecraft.superbvote.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.minimum.minecraft.superbvote.SuperbVote;
 import java.util.Date;
-import javax.annotation.Nullable;
-import lombok.Value;
-import org.bukkit.Bukkit;
-
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
+import org.bukkit.Bukkit;
 
 @Value
 public class PlayerVotes {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final UUID uuid;
     private final String associatedUsername;
     private final int votes;
-    @Nullable
-    private final Date lastVote;
+    private final Map<String, Date> lastVotes;
     private final Type type;
 
     public String getAssociatedUsername() {
@@ -25,6 +33,55 @@ public class PlayerVotes {
 
     public enum Type {
         CURRENT,
-        FUTURE
+        FUTURE;
+
+    }
+    public boolean hasVoteOnSameDay(String serviceName, Date voteDate) {
+        Date lastVoteDate = lastVotes.get(serviceName);
+        if (lastVoteDate == null) {
+            return false;
+        }
+        if (lastVoteDate.equals(voteDate)) {
+            // the new vote is just about being processed right now
+            return false;
+        }
+        return DateUtils.isSameDay(lastVoteDate, voteDate);
+    }
+
+    public void updateLastVotes(String serviceName, Date voteReceived) {
+        lastVotes.put(serviceName, voteReceived);
+    }
+
+    public String getSerializedLastVotes() {
+        try {
+            Map<String, Date> preprocessed = new HashMap<>();
+            for (Map.Entry<String, Date> entry : lastVotes.entrySet()) {
+                long dateSeconds = entry.getValue().getTime() / 1000;
+                preprocessed.put(entry.getKey(), new Date(dateSeconds));
+            }
+            return OBJECT_MAPPER.writeValueAsString(preprocessed);
+        } catch (JsonProcessingException e) {
+            SuperbVote.getPlugin()
+                    .getLogger()
+                    .severe("Could not serialize last votes to JSON: " + lastVotes + "\n" + e.getMessage());
+            return "";
+        }
+    }
+
+    public static Map<String, Date> deserializeLastVotes(String lastVotesString) {
+        if (StringUtils.isBlank(lastVotesString)) {
+            return new HashMap<>();
+        }
+        try {
+            Map<String, Long> lastVotes = OBJECT_MAPPER.readValue(lastVotesString, new TypeReference<>() {});
+            return lastVotes.entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> new Date(e.getValue() * 1000)));
+        } catch (JsonProcessingException e) {
+            SuperbVote.getPlugin()
+                    .getLogger()
+                    .severe("Could not deserialize last votes from JSON: " + lastVotesString + "\n" + e.getMessage());
+            return new HashMap<>();
+        }
     }
 }

--- a/src/main/java/io/minimum/minecraft/superbvote/util/PlayerVotes.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/util/PlayerVotes.java
@@ -24,6 +24,14 @@ public class PlayerVotes {
     private final Map<String, Date> lastVotes;
     private final Type type;
 
+    public PlayerVotes(UUID uuid, String associatedUsername, int votes, Map<String, Date> lastVotes, Type type) {
+        this.uuid = uuid;
+        this.associatedUsername = associatedUsername;
+        this.votes = votes;
+        this.lastVotes = new HashMap<>(lastVotes);
+        this.type = type;
+    }
+
     public String getAssociatedUsername() {
         if (associatedUsername == null) {
             return Bukkit.getOfflinePlayer(uuid).getName();

--- a/src/main/java/io/minimum/minecraft/superbvote/util/PlayerVotes.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/util/PlayerVotes.java
@@ -1,5 +1,7 @@
 package io.minimum.minecraft.superbvote.util;
 
+import java.util.Date;
+import javax.annotation.Nullable;
 import lombok.Value;
 import org.bukkit.Bukkit;
 
@@ -10,6 +12,8 @@ public class PlayerVotes {
     private final UUID uuid;
     private final String associatedUsername;
     private final int votes;
+    @Nullable
+    private final Date lastVote;
     private final Type type;
 
     public String getAssociatedUsername() {

--- a/src/main/java/io/minimum/minecraft/superbvote/util/SpigotUpdater.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/util/SpigotUpdater.java
@@ -1,7 +1,7 @@
 package io.minimum.minecraft.superbvote.util;
 
 import com.google.common.io.ByteStreams;
-import io.minimum.minecraft.superbvote.SuperbVote;;
+import io.minimum.minecraft.superbvote.SuperbVote;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
@@ -39,7 +39,7 @@ public class SpigotUpdater implements Runnable, Listener {
     @Override
     public void run() {
         String myVersion = SuperbVote.getPlugin().getDescription().getVersion();
-        if (myVersion.endsWith("-SNAPSHOT")) {
+        if (myVersion.endsWith("-SNAPSHOT") || myVersion.endsWith("-CORP")) {
             // Nothing to do.
             return;
         }

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -36,7 +36,14 @@ public class SuperbVoteListener implements Listener {
         }
 
         Bukkit.getScheduler().runTaskAsynchronously(SuperbVote.getPlugin(), () -> {
-            OfflinePlayer op = Bukkit.getOfflinePlayer(event.getVote().getUsername());
+            String voteUsername = event.getVote()
+                    .getUsername();
+            OfflinePlayer op = Bukkit.getOfflinePlayer(voteUsername);
+            if (!op.hasPlayedBefore()) {
+                SuperbVote.getPlugin().getLogger().log(Level.WARNING, "Ignoring vote from " + voteUsername +
+                        " (service: " + event.getVote().getServiceName() + "): Unknown player.");
+                return;
+            }
             String worldName = null;
             if (op.isOnline()) {
                 worldName = op.getPlayer().getWorld().getName();

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -3,6 +3,7 @@ package io.minimum.minecraft.superbvote.votes;
 import com.vexsoftware.votifier.model.VotifierEvent;
 import io.minimum.minecraft.superbvote.SuperbVote;
 import io.minimum.minecraft.superbvote.commands.SuperbVoteCommand;
+import io.minimum.minecraft.superbvote.configuration.SuperbVoteConfiguration;
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
 import io.minimum.minecraft.superbvote.signboard.TopPlayerSignFetcher;
 import io.minimum.minecraft.superbvote.storage.MysqlVoteStorage;
@@ -88,6 +89,14 @@ public class SuperbVoteListener implements Listener {
             throw new RuntimeException("No vote rewards found for '" + vote + "'");
         }
 
+        boolean hasAlreadyVoted = SuperbVote.getPlugin()
+                .getVoteStorage()
+                .hasVotedToday(vote.getUuid()); // TODO: use getVotes(vote.getReceived()) and add lastVote to PlayerVotes
+        if (hasAlreadyVoted && SuperbVote.getPlugin().getConfig().getBoolean("votes.one-vote-per-day")) {
+            Date todoReplace = new Date(); // TODO: replace with lastVote date
+            SuperbVote.getPlugin().getLogger().log(Level.INFO, "Discarding vote: " + vote.getName() + " already voted the same day at " + todoReplace);
+            return;
+        }
         if (queue) {
             if (!SuperbVote.getPlugin().getConfiguration().shouldQueueVotes()) {
                 SuperbVote.getPlugin().getLogger().log(Level.WARNING, "Ignoring vote from " + vote.getName() + " (service: " +

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -90,9 +90,9 @@ public class SuperbVoteListener implements Listener {
             throw new RuntimeException("No vote rewards found for '" + vote + "'");
         }
 
-        if (pv.getLastVote() != null
-            && DateUtils.isSameDay(pv.getLastVote(), vote.getReceived())
-            && SuperbVote.getPlugin().getConfig().getBoolean("votes.one-vote-per-day")) {
+        if (SuperbVote.getPlugin().getConfig().getBoolean("votes.one-vote-per-day")
+            && pv.getLastVote() != null
+            && DateUtils.isSameDay(pv.getLastVote(), vote.getReceived())) {
 
             SuperbVote.getPlugin()
                     .getLogger()

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/matchers/RewardMatchers.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/matchers/RewardMatchers.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.minimum.minecraft.superbvote.SuperbVote;
 import net.milkbowl.vault.permission.Permission;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.RegisteredServiceProvider;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,9 @@ votes:
   # Whether or not to treat fake votes as real votes
   process-fake-votes: true
 
+  # Whether to allow only one vote per day for each player
+  one-vote-per-day: false
+
 # Streaks configuration
 # Important: Streaks does not support JSON storage
 streaks:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,11 +9,6 @@ commands:
   superbvote:
     description: SuperbVote main command.
     aliases: [sv]
-  vote:
-    description: SuperbVote vote command.
-  votestreak:
-    description: SuperbVote vote streak command.
-    aliases: [vstreak]
 permissions:
   superbvote.notify:
     default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ author: tuxed
 version: ${project.version}
 depend: [Votifier]
 softdepend: [Vault, PlaceholderAPI]
-api-version: "1.13"
+api-version: "1.19"
 commands:
   superbvote:
     description: SuperbVote main command.


### PR DESCRIPTION
This PR adds a new feature which allows to restrict maximum votes to one vote per day to prevent a player receiving a daily vote reward twice. 
The `votes.one-vote-per-day` configuration option is optional (default: `false` = old behaviour).